### PR TITLE
Support per-topic permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Follow these steps to interact with a robot using the web visualizer:
     * Authorize each user to at least **receive** messages.
     * To allow robot control, allow the user to **send** messages.
 
-**Unstable**: Currently, there is no way to allow sending and receiving on a per-topic basis.
+In addition to allowing clients to send or receive all messages, you can allow clients to send or receive messages **on topics matching a given regular expression**.
+See the example configuration for details.
 
 #### Special topics
 

--- a/src/access.test.ts
+++ b/src/access.test.ts
@@ -211,3 +211,66 @@ test("Authorizes multiple kinds of identities", () => {
     op: "receive"
   })).toBe(true);
 });
+
+test("Authorizes matching topics when topicRegex is specified", () => {
+  const authorize = makeAuthorizer({
+    permissions: [
+      {
+        ip: "1.2.3.4",
+        allow: [{op: "receive", topicRegex: "my/t(opic|aco)"}],
+      }
+    ]
+  });
+
+  expect(authorize({
+    ip: "1.2.3.4",
+    op: "receive",
+    topic: "my/topic"
+  })).toBe(true);
+
+  expect(authorize({
+    ip: "1.2.3.4",
+    op: "receive",
+    topic: "my/taco"
+  })).toBe(true);
+});
+
+test("Doesn't authorize partially-matching topics when topicRegex is specified", () => {
+  const authorize = makeAuthorizer({
+    permissions: [
+      {
+        ip: "1.2.3.4",
+        allow: [{op: "receive", topicRegex: "topic"}],
+      }
+    ]
+  });
+
+  expect(authorize({
+    ip: "1.2.3.4",
+    op: "receive",
+    topic: "topic"
+  })).toBe(true);
+
+  expect(authorize({
+    ip: "1.2.3.4",
+    op: "receive",
+    topic: "my/topic"
+  })).toBe(false);
+});
+
+test("Doesn't authorize non-matching topics when topicRegex is specified", () => {
+  const authorize = makeAuthorizer({
+    permissions: [
+      {
+        ip: "1.2.3.4",
+        allow: [{op: "receive", topicRegex: "my/t(opic|aco)"}],
+      }
+    ]
+  });
+
+  expect(authorize({
+    ip: "1.2.3.4",
+    op: "receive",
+    topic: "my/tortoise"
+  })).toBe(false);
+});

--- a/src/access.ts
+++ b/src/access.ts
@@ -6,12 +6,13 @@ export function isOp(x: any): x is Op {
   return (typeof x === "string") && (x === "send" || x === "receive");
 }
 
+export type Action = Op | {op: Op, topicRegex: string};
 export interface AuthConfig {
   permissions: Array<{
     ip?: string,
     ipRange?: [string, string],
     email?: string,
-    allow: Array<Op>,
+    allow: Array<Action>,
   }>,
   [other: string]: any
 }
@@ -32,32 +33,45 @@ export function makeAuthorizer(config: AuthConfig) {
 
     const ipAddr = (typeof ip !== "undefined") ? ip6addr.parse(ip) : null;
     
-    for (let grant of config.permissions) {
+    for (const grant of config.permissions) {
       // is this item granting permission for the requested operation?
-      if (grant.allow.includes(op)) {
-        // does the request include an IP? Do IP-based auth
-        if (ipAddr) {
-          // does this item grant permission to a particular IP?
-          if (grant.ip) {
-            const grantIpAddr = ip6addr.parse(grant.ip);
-            if (grantIpAddr.compare(ipAddr) === 0) {
-              return true;
-            }
-          }
-
-          // does this item grant permission to a range of IPs?
-          if (grant.ipRange) {
-            const grantIpRange = ip6addr.createAddrRange(grant.ipRange[0], grant.ipRange[1]);
-            if (grantIpRange.contains(ipAddr.toString())) {
-              return true;
-            }
-          }
+      for (const action of grant.allow) {
+        // does the attempted action match this allowed action?
+        let actionAllowed = false;
+        if (isOp(action)) {
+          actionAllowed = op === action;
+        } else {
+          const topicRegex = new RegExp(action.topicRegex);
+          const match = topic.match(topicRegex);
+          const topicMatches = match !== null && match[0] === topic;
+          actionAllowed = op === action.op && topicMatches;
         }
 
-        // does the request include an email? Do email-based auth
-        if (email && grant.email) {
-          if (email === grant.email) {
-            return true;
+        if (actionAllowed) {
+          // does the request include an IP? Do IP-based auth
+          if (ipAddr) {
+            // does this item grant permission to a particular IP?
+            if (grant.ip) {
+              const grantIpAddr = ip6addr.parse(grant.ip);
+              if (grantIpAddr.compare(ipAddr) === 0) {
+                return true;
+              }
+            }
+
+            // does this item grant permission to a range of IPs?
+            if (grant.ipRange) {
+              const grantIpRange = ip6addr.createAddrRange(grant.ipRange[0], grant.ipRange[1]);
+              if (grantIpRange.contains(ipAddr.toString())) {
+                return true;
+              }
+            }
+          }
+
+          // does the request include an email? Do email-based auth
+          if (email && grant.email) {
+            if (email === grant.email) {
+              return true;
+            }
           }
         }
       }

--- a/src/config.example.ts
+++ b/src/config.example.ts
@@ -2,7 +2,7 @@
 
 import { AuthConfig } from "./access";
 
-export default {
+const config: AuthConfig = {
     serverPort: 8080,
     useSecure: false,
     certPath: "example.pem",
@@ -29,5 +29,6 @@ export default {
         // grant receive access for my/topic on any robot
         // {email: "logan@example.org", allow: [{op: "receive", topicRegex: "/[^/]+/my/topic"}]},
     ],
-} as AuthConfig;
+};
 
+export default config;

--- a/src/config.example.ts
+++ b/src/config.example.ts
@@ -22,6 +22,12 @@ export default {
 
         // grant full access to a particular email address
         // {email: "logan@example.org", allow: ["send", "receive"]},
+
+        // grant receive access for my/topic on a particular robot
+        // {email: "logan@example.org", allow: [{op: "receive", topicRegex: "/jackal/my/topic"}]},
+
+        // grant receive access for my/topic on any robot
+        // {email: "logan@example.org", allow: [{op: "receive", topicRegex: "/[^/]+/my/topic"}]},
     ],
 } as AuthConfig;
 


### PR DESCRIPTION
This adds the ability to restrict send/receive permissions to topics matching a particular regex to fix #7. This is optional, and the new configuration syntax is backward compatible with existing configuration files.