### PR TITLE
add config for db storage path

### DIFF
--- a/src/config.example.ts
+++ b/src/config.example.ts
@@ -9,6 +9,8 @@ export default {
     keyPath: "example.key",
     // OAuth client ID
     clientId: null,
+    // Path to the root folder for the robot db
+    robotDbPath: 'robofleet-robots', 
     permissions: [
         // full access to localhost
         {ip: "127.0.0.1", allow: ["send", "receive"]},

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -3,7 +3,7 @@ import levelup from 'levelup'
 import leveldown from 'leveldown'
 import RobotInformation from './robot';
 
-var robotDbInstance = levelup(leveldown('robofleet-robots'));
+var robotDbInstance = levelup(leveldown(config.robotDbPath));
 
 export function robotDb() {
   return robotDbInstance;


### PR DESCRIPTION
We can't just assume we have write access in the folder from which we run the server, so make it a config flag.

On robofleet, this will be set to `/var/www/robofleet-db/` or something similar